### PR TITLE
Fix Vector Search Options and add missing files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,4 +3,3 @@
 .vs
 /src/Demo/appsettings.json
 appsettings.json
-stylecop.json

--- a/src/Demo/Plugins/Search.cs
+++ b/src/Demo/Plugins/Search.cs
@@ -35,9 +35,7 @@ public class Search
         var vectorSearch = _collection as IVectorizedSearch<Paragraph>;
         var searchVector = await _embeddingGenerationService.GenerateEmbeddingAsync(query);
         var searchResult = (
-            await vectorSearch!
-                .VectorizedSearchAsync(searchVector, new() { Limit = 1 })
-                .ToListAsync()
+            await vectorSearch!.VectorizedSearchAsync(searchVector, new() { Top = 1 }).ToListAsync()
         )
             .First()
             .Record.Text;

--- a/src/Demo/appsettings.example.json
+++ b/src/Demo/appsettings.example.json
@@ -1,0 +1,13 @@
+{
+  "AzureOpenAIConfig": {
+    "ChatModelDeploymentName": "<ChatModelDeploymentName>",
+    "EmbeddingModelDeploymentName": "<EmbeddingModelDeploymentName>",
+    "Endpoint": "<Endpoint>",
+    "ApiKey": "<ApiKey>"
+  },
+  "EvaluatorAzureOpenAIConfig": {
+    "ChatModelDeploymentName": "<ChatModelDeploymentName>",
+    "Endpoint": "<Endpoint>",
+    "ApiKey": "<ApiKey>"
+  }
+}

--- a/src/Micronaire/stylecop.json
+++ b/src/Micronaire/stylecop.json
@@ -1,0 +1,11 @@
+{
+  "$schema": "https://raw.githubusercontent.com/DotNetAnalyzers/StyleCopAnalyzers/master/StyleCop.Analyzers/StyleCop.Analyzers/Settings/stylecop.schema.json",
+  "settings": {
+    "documentationRules": {
+      "companyName": "Microsoft"
+    },
+    "orderingRules": {
+      "usingDirectivesPlacement": "outsideNamespace"
+    }
+  }
+}


### PR DESCRIPTION
This PR fixes the upstream change to `VectorSearchOptions` by Semantic Kernel by renaming `Limit` to `Top`.

It also adds an example `appsettings.json` and adds the missing stylecop file

#4 #5 