### PR TITLE
Move to Semantic Kernel 1.30.0 without local references

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,3 @@
+{
+    "sarif-viewer.connectToGithubCodeScanning": "off"
+}

--- a/src/Demo/Demo.csproj
+++ b/src/Demo/Demo.csproj
@@ -9,15 +9,17 @@
 	</PropertyGroup>
 
 	<ItemGroup>
-		<ProjectReference Include="..\..\external\semantic-kernel\dotnet\src\SemanticKernel.Core\SemanticKernel.Core.csproj" />
-		<ProjectReference Include="..\..\external\semantic-kernel\dotnet\src\SemanticKernel.Abstractions\SemanticKernel.Abstractions.csproj" />
-		<ProjectReference Include="..\..\external\semantic-kernel\dotnet\src\Connectors\Connectors.AzureOpenAI\Connectors.AzureOpenAI.csproj" />
-		<ProjectReference Include="..\..\external\semantic-kernel\dotnet\samples\Concepts\Concepts.csproj" />
 		<ProjectReference Include="..\Micronaire\Micronaire.csproj" />
 	</ItemGroup>
 
 	<ItemGroup>
+		<PackageReference Include="Docker.DotNet" Version="3.125.15" />
 		<PackageReference Include="Microsoft.Extensions.Hosting" Version="8.0.0" />
+		<PackageReference Include="Microsoft.SemanticKernel" Version="1.30.0" />
+		<PackageReference Include="Microsoft.SemanticKernel.Connectors.Qdrant" Version="1.30.0-preview" />
+		<PackageReference Include="Microsoft.SemanticKernel.Plugins.Memory" Version="1.30.0-alpha" />
+		<PackageReference Include="Qdrant.Client" Version="1.12.0" />
+		<PackageReference Include="System.Linq.Async" Version="6.0.1" />
 	</ItemGroup>
 
 	<ItemGroup>
@@ -27,10 +29,10 @@
 	</ItemGroup>
 	<ItemGroup>
 		<None Update="data\GroundTruthAnswers.json">
-		  <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+			<CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
 		</None>
 		<None Update="data\GroundTruthAnswersMinimal.json">
-		  <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+			<CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
 		</None>
 		<None Update="data\Romeo and Juliet.txt">
 			<CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>

--- a/src/Demo/Models/Paragraph.cs
+++ b/src/Demo/Models/Paragraph.cs
@@ -1,10 +1,9 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
-using Microsoft.SemanticKernel.Data;
+using Microsoft.Extensions.VectorData;
 
 namespace Demo;
 
-#pragma warning disable SKEXP0001
 public class Paragraph
 {
     [VectorStoreRecordKey]
@@ -16,4 +15,3 @@ public class Paragraph
     [VectorStoreRecordVector(Dimensions: 1536)]
     public ReadOnlyMemory<float> Embedding { get; set; }
 }
-#pragma warning restore SKEXP0001

--- a/src/Demo/Pipeline/RagPipeline.cs
+++ b/src/Demo/Pipeline/RagPipeline.cs
@@ -2,11 +2,11 @@
 // Licensed under the MIT License.
 using Micronaire;
 using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.VectorData;
 using Microsoft.SemanticKernel;
 using Microsoft.SemanticKernel.ChatCompletion;
 using Microsoft.SemanticKernel.Connectors.AzureOpenAI;
 using Microsoft.SemanticKernel.Connectors.OpenAI;
-using Microsoft.SemanticKernel.Data;
 using Microsoft.SemanticKernel.Embeddings;
 using Microsoft.SemanticKernel.Text;
 

--- a/src/Demo/Plugins/Search.cs
+++ b/src/Demo/Plugins/Search.cs
@@ -2,8 +2,8 @@
 // Licensed under the MIT License.
 using System.ComponentModel;
 using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.VectorData;
 using Microsoft.SemanticKernel;
-using Microsoft.SemanticKernel.Data;
 using Microsoft.SemanticKernel.Embeddings;
 
 namespace Demo;
@@ -34,11 +34,9 @@ public class Search
     {
         var vectorSearch = _collection as IVectorizedSearch<Paragraph>;
         var searchVector = await _embeddingGenerationService.GenerateEmbeddingAsync(query);
-        var searchResult = (
-            await vectorSearch!.VectorizedSearchAsync(searchVector, new() { Top = 1 }).ToListAsync()
-        )
-            .First()
-            .Record.Text;
+        var searchResults = await vectorSearch!.VectorizedSearchAsync(searchVector, new() { Top = 1 });
+        var firstResult = await searchResults.Results.FirstAsync();
+        var searchResult = firstResult.Record.Text;
         _logger.LogInformation("Got search result:\n{searchResult}", searchResult);
         return searchResult;
     }

--- a/src/Demo/Program.cs
+++ b/src/Demo/Program.cs
@@ -1,12 +1,9 @@
 ﻿// Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 using Demo;
-using Memory.VectorStoreFixtures;
 using Micronaire;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Hosting;
-
-#pragma warning disable SKEXP0001
 
 var qdrantFixture = new VectorStoreQdrantContainerFixture();
 await qdrantFixture.ManualInitializeAsync();
@@ -48,4 +45,3 @@ finally
 {
     await qdrantFixture.DisposeAsync();
 }
-#pragma warning restore SKEXP0001

--- a/src/Demo/VectorStoreInfra.cs
+++ b/src/Demo/VectorStoreInfra.cs
@@ -1,0 +1,108 @@
+// Copyright (c) Microsoft. All rights reserved.
+
+using Docker.DotNet;
+using Docker.DotNet.Models;
+
+namespace Demo;
+
+/// <summary>
+/// Helper class that creates and deletes containers for the vector store examples.
+/// </summary>
+internal static class VectorStoreInfra
+{
+    /// <summary>
+    /// Setup the qdrant container by pulling the image and running it.
+    /// </summary>
+    /// <param name="client">The docker client to create the container with.</param>
+    /// <returns>The id of the container.</returns>
+    public static async Task<string> SetupQdrantContainerAsync(DockerClient client)
+    {
+        await client.Images.CreateImageAsync(
+            new ImagesCreateParameters
+            {
+                FromImage = "qdrant/qdrant",
+                Tag = "latest",
+            },
+            null,
+            new Progress<JSONMessage>());
+
+        var container = await client.Containers.CreateContainerAsync(new CreateContainerParameters()
+        {
+            Image = "qdrant/qdrant",
+            HostConfig = new HostConfig()
+            {
+                PortBindings = new Dictionary<string, IList<PortBinding>>
+                {
+                    {"6333", new List<PortBinding> {new() {HostPort = "6333" } }},
+                    {"6334", new List<PortBinding> {new() {HostPort = "6334" } }}
+                },
+                PublishAllPorts = true
+            },
+            ExposedPorts = new Dictionary<string, EmptyStruct>
+            {
+                { "6333", default },
+                { "6334", default }
+            },
+        });
+
+        await client.Containers.StartContainerAsync(
+            container.ID,
+            new ContainerStartParameters());
+
+        return container.ID;
+    }
+
+    /// <summary>
+    /// Setup the redis container by pulling the image and running it.
+    /// </summary>
+    /// <param name="client">The docker client to create the container with.</param>
+    /// <returns>The id of the container.</returns>
+    public static async Task<string> SetupRedisContainerAsync(DockerClient client)
+    {
+        await client.Images.CreateImageAsync(
+            new ImagesCreateParameters
+            {
+                FromImage = "redis/redis-stack",
+                Tag = "latest",
+            },
+            null,
+            new Progress<JSONMessage>());
+
+        var container = await client.Containers.CreateContainerAsync(new CreateContainerParameters()
+        {
+            Image = "redis/redis-stack",
+            HostConfig = new HostConfig()
+            {
+                PortBindings = new Dictionary<string, IList<PortBinding>>
+                {
+                    {"6379", new List<PortBinding> {new() {HostPort = "6379"}}},
+                    {"8001", new List<PortBinding> {new() {HostPort = "8001"}}}
+                },
+                PublishAllPorts = true
+            },
+            ExposedPorts = new Dictionary<string, EmptyStruct>
+            {
+                { "6379", default },
+                { "8001", default }
+            },
+        });
+
+        await client.Containers.StartContainerAsync(
+            container.ID,
+            new ContainerStartParameters());
+
+        return container.ID;
+    }
+
+    /// <summary>
+    /// Stop and delete the container with the specified id.
+    /// </summary>
+    /// <param name="client">The docker client to delete the container in.</param>
+    /// <param name="containerId">The id of the container to delete.</param>
+    /// <returns>An async task.</returns>
+    public static async Task DeleteContainerAsync(DockerClient client, string containerId)
+    {
+        await client.Containers.StopContainerAsync(containerId, new ContainerStopParameters());
+        await client.Containers.RemoveContainerAsync(containerId, new ContainerRemoveParameters());
+    }
+}

--- a/src/Demo/VectorStoreQdrantContainerFixture.cs
+++ b/src/Demo/VectorStoreQdrantContainerFixture.cs
@@ -1,0 +1,52 @@
+// Copyright (c) Microsoft. All rights reserved.
+
+using Docker.DotNet;
+using Qdrant.Client;
+
+namespace Demo;
+
+/// <summary>
+/// Fixture to use for creating a Qdrant container before tests and delete it after tests.
+/// </summary>
+public class VectorStoreQdrantContainerFixture
+{
+    private DockerClient? _dockerClient;
+    private string? _qdrantContainerId;
+
+    public async Task ManualInitializeAsync()
+    {
+        if (this._qdrantContainerId == null)
+        {
+            // Connect to docker and start the docker container.
+            using var dockerClientConfiguration = new DockerClientConfiguration();
+            this._dockerClient = dockerClientConfiguration.CreateClient();
+            this._qdrantContainerId = await VectorStoreInfra.SetupQdrantContainerAsync(this._dockerClient);
+
+            // Delay until the Qdrant server is ready.
+            var qdrantClient = new QdrantClient("localhost");
+            var succeeded = false;
+            var attemptCount = 0;
+            while (!succeeded && attemptCount++ < 10)
+            {
+                try
+                {
+                    await qdrantClient.ListCollectionsAsync();
+                    succeeded = true;
+                }
+                catch (Exception)
+                {
+                    await Task.Delay(1000);
+                }
+            }
+        }
+    }
+
+    public async Task DisposeAsync()
+    {
+        if (this._dockerClient != null && this._qdrantContainerId != null)
+        {
+            // Delete docker container.
+            await VectorStoreInfra.DeleteContainerAsync(this._dockerClient, this._qdrantContainerId);
+        }
+    }
+}

--- a/src/Micronaire/Micronaire.csproj
+++ b/src/Micronaire/Micronaire.csproj
@@ -19,9 +19,9 @@
   </ItemGroup>
 
   <ItemGroup>
-    <None Include="..\..\LICENSE" Pack="true" PackagePath=""/>
-    <None Include="..\..\README.md" Pack="true" PackagePath=""/>
-    <None Include="..\..\img\micronaire-logo.png" Pack="true" PackagePath=""/>
+    <None Include="..\..\LICENSE" Pack="true" PackagePath="" />
+    <None Include="..\..\README.md" Pack="true" PackagePath="" />
+    <None Include="..\..\img\micronaire-logo.png" Pack="true" PackagePath="" />
   </ItemGroup>
 
   <ItemGroup>
@@ -29,17 +29,14 @@
   </ItemGroup>
 
   <ItemGroup>
+    <PackageReference Include="Microsoft.Extensions.Configuration" Version="9.0.0" />
+    <PackageReference Include="Microsoft.Extensions.Http" Version="9.0.0" />
+    <PackageReference Include="Microsoft.Extensions.Http.Resilience" Version="9.0.0" />
+    <PackageReference Include="Microsoft.SemanticKernel" Version="1.30.0" />
+    <PackageReference Include="Newtonsoft.Json" Version="13.0.3" />
     <PackageReference Include="StyleCop.Analyzers" Version="1.2.0-beta.556">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
   </ItemGroup>
-	
-   <ItemGroup>
-    <ProjectReference Include="..\..\external\semantic-kernel\dotnet\src\SemanticKernel.Core\SemanticKernel.Core.csproj" />
-    <ProjectReference Include="..\..\external\semantic-kernel\dotnet\src\SemanticKernel.Abstractions\SemanticKernel.Abstractions.csproj" />
-    <ProjectReference Include="..\..\external\semantic-kernel\dotnet\src\Connectors\Connectors.AzureOpenAI\Connectors.AzureOpenAI.csproj" />
-    <ProjectReference Include="..\..\external\semantic-kernel\dotnet\samples\Concepts\Concepts.csproj" />
-  </ItemGroup>
-
 </Project>

--- a/src/Micronaire/stylecop.json
+++ b/src/Micronaire/stylecop.json
@@ -2,7 +2,8 @@
   "$schema": "https://raw.githubusercontent.com/DotNetAnalyzers/StyleCopAnalyzers/master/StyleCop.Analyzers/StyleCop.Analyzers/Settings/stylecop.schema.json",
   "settings": {
     "documentationRules": {
-      "companyName": "Microsoft"
+      "companyName": "Microsoft",
+      "xmlHeader": false
     },
     "orderingRules": {
       "usingDirectivesPlacement": "outsideNamespace"


### PR DESCRIPTION
This PR moves Micronaire to use Semantic Kernel 1.30.0 without having to reference the development branch for vector stores